### PR TITLE
Updated visualization apps URLs

### DIFF
--- a/data/rdf/discovery-input/application/dcterms/template.ttl
+++ b/data/rdf/discovery-input/application/dcterms/template.ttl
@@ -12,7 +12,7 @@
      lpd:componentConfigurationTemplate application:defaultConfiguration ;
      lpd:inputTemplate application:input ;
      lpd:feature application:defaultFeature ;
-     lpd:executor <https://visualisation-apps.netlify.com/dcterms> .
+     lpd:executor <https://visualization-apps.netlify.com/dct> .
 
  configuration-vocabulary:Configuration a rdfs:Class ;
      rdfs:label "Class of configurations of DCTerms Application"@en;

--- a/data/rdf/discovery-input/application/map-labeled-points/template.ttl
+++ b/data/rdf/discovery-input/application/map-labeled-points/template.ttl
@@ -11,7 +11,7 @@
      lpd:componentConfigurationTemplate application:defaultConfiguration ;
      lpd:inputTemplate application:input ;
      lpd:feature application:defaultFeature ;
-     lpd:executor <https://visualisation-apps.netlify.com/map> .
+     lpd:executor <https://visualization-apps.netlify.com/map> .
 
  configuration-vocabulary:Configuration a rdfs:Class ;
      rdfs:label "Class of configurations of Map Application with labeled points"@en;

--- a/data/rdf/discovery-input/application/map/template.ttl
+++ b/data/rdf/discovery-input/application/map/template.ttl
@@ -11,7 +11,7 @@
      lpd:componentConfigurationTemplate application:defaultConfiguration ;
      lpd:inputTemplate application:input ;
      lpd:feature application:defaultFeature ;
-     lpd:executor <https://visualisation-apps.netlify.com/map> .
+     lpd:executor <https://visualization-apps.netlify.com/map> .
 
  configuration-vocabulary:Configuration a rdfs:Class ;
      rdfs:label "Class of configurations of Map Application"@en;

--- a/data/rdf/discovery-input/application/timeline-periods-with-labels/template.ttl
+++ b/data/rdf/discovery-input/application/timeline-periods-with-labels/template.ttl
@@ -11,7 +11,7 @@
      lpd:componentConfigurationTemplate application:defaultConfiguration ;
      lpd:inputTemplate application:input ;
      lpd:feature application:defaultFeature ;
-     lpd:executor <https://visualisation-apps.netlify.com/timeline> .
+     lpd:executor <https://visualization-apps.netlify.com/timeline> .
 
  configuration-vocabulary:Configuration a rdfs:Class ;
      rdfs:label "Class of configurations of Timeline with labeled periods of time Application"@en;

--- a/data/rdf/discovery-input/application/timeline-periods/template.ttl
+++ b/data/rdf/discovery-input/application/timeline-periods/template.ttl
@@ -11,7 +11,7 @@
      lpd:componentConfigurationTemplate application:defaultConfiguration ;
      lpd:inputTemplate application:input ;
      lpd:feature application:defaultFeature ;
-     lpd:executor <https://visualisation-apps.netlify.com/timeline> .
+     lpd:executor <https://visualization-apps.netlify.com/timeline> .
 
  configuration-vocabulary:Configuration a rdfs:Class ;
      rdfs:label "Class of configurations of Timeline with periods of time Application"@en;

--- a/data/rdf/discovery-input/application/timeline-with-labels/template.ttl
+++ b/data/rdf/discovery-input/application/timeline-with-labels/template.ttl
@@ -11,7 +11,7 @@
      lpd:componentConfigurationTemplate application:defaultConfiguration ;
      lpd:inputTemplate application:input ;
      lpd:feature application:defaultFeature ;
-     lpd:executor <https://visualisation-apps.netlify.com/timeline-with-labels> .
+     lpd:executor <https://visualization-apps.netlify.com/timeline> .
 
  configuration-vocabulary:Configuration a rdfs:Class ;
      rdfs:label "Class of configurations of Labeled timeline Application"@en;

--- a/data/rdf/discovery-input/application/timeline/template.ttl
+++ b/data/rdf/discovery-input/application/timeline/template.ttl
@@ -11,7 +11,7 @@
      lpd:componentConfigurationTemplate application:defaultConfiguration ;
      lpd:inputTemplate application:input ;
      lpd:feature application:defaultFeature ;
-     lpd:executor <https://visualisation-apps.netlify.com/timeline> .
+     lpd:executor <https://visualization-apps.netlify.com/timeline> .
 
  configuration-vocabulary:Configuration a rdfs:Class ;
      rdfs:label "Class of configurations of Timeline Application"@en;


### PR DESCRIPTION
1. `visualisation-apps` -> `visualization-apps`
2. `dcterms` -> `dct`
3. `timeline-with-labels` -> `timeline`

Note: some apps / links might be broken until this is merged.